### PR TITLE
Support unknown charger op modes

### DIFF
--- a/lib/easee/state.rb
+++ b/lib/easee/state.rb
@@ -1,5 +1,7 @@
 module Easee
   class State
+    OP_MODE_UNKNOWN = :unknown
+
     CHARGER_OP_MODES = {
       0 => :offline,
       1 => :disconnected,
@@ -27,6 +29,9 @@ module Easee
 
     private
 
-    def charger_op_mode = CHARGER_OP_MODES.fetch(@data.fetch(:chargerOpMode))
+    def charger_op_mode
+      numeric_op_mode = @data.fetch(:chargerOpMode)
+      CHARGER_OP_MODES.fetch(numeric_op_mode) { OP_MODE_UNKNOWN }
+    end
   end
 end

--- a/spec/easee/state_spec.rb
+++ b/spec/easee/state_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Easee::State do
     it "returns false for all other charger op modes" do
       expect(Easee::State.new(chargerOpMode: 4)).not_to be_charging
     end
+
+    it "does not fail for unknown op modes" do
+      expect(Easee::State.new(chargerOpMode: 7)).not_to be_charging
+    end
   end
 
   describe "#disconnected?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "timecop"
 require "webmock/rspec"
-require "easee"
+require "stekker_easee"
 
 Dir["spec/support/**/*.rb"].each { |f| require_relative "../#{f}" }
 


### PR DESCRIPTION
According to our error logs, the charger op mode can be something other than 0..6 (7 in this case). We should support it and return :unknown instead of letting `fetch` raise an error.