### PR TITLE
Support `nil` country for site address

### DIFF
--- a/lib/easee/site.rb
+++ b/lib/easee/site.rb
@@ -9,11 +9,13 @@ module Easee
     def building_number = address.fetch(:buildingNumber)
     def zip = address.fetch(:zip)
     def area = address.fetch(:area)
-    def country_id = address.fetch(:country).fetch(:id)
+    def country_id = country[:id]
     def latitude = address.fetch(:latitude)
     def longitude = address.fetch(:longitude)
 
     private
+
+    def country = address.fetch(:country) || {}
 
     def address
       @address ||= @data.fetch(:address)

--- a/spec/easee/site_spec.rb
+++ b/spec/easee/site_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Easee::Site do
+  describe "#country_id" do
+    it "returns nil when the address country is nil" do
+      site = Easee::Site.new(address: { country: nil })
+
+      expect(site.country_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
For some chargers, the `country` key in the `address` for a site can be nil. `country_id` should be able to handle that and return `nil` when `country` is `nil`.