### PR TITLE
Implement poll_lifetime_energy method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -53,6 +53,11 @@ module Easee
       post("/api/chargers/#{charger_id}/commands/resume_charging")
     end
 
+    # https://developer.easee.com/reference/post_api-chargers-chargerid-commands-poll-lifetimeenergy
+    def poll_lifetime_energy(charger_id)
+      post("/api/chargers/#{charger_id}/commands/poll_lifetimeenergy")
+    end
+
     # https://developer.easee.cloud/reference/get_api-chargers-id-config
     def configuration(charger_id)
       get("/api/chargers/#{charger_id}/config")

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -412,6 +412,26 @@ RSpec.describe Easee::Client do
     end
   end
 
+  describe "#poll_lifetime_energy" do
+    it "sends a poll_lifetimeenergy command" do
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      token_cache.write(
+        Easee::Client::TOKENS_CACHE_KEY,
+        { "accessToken" => "T123" }.to_json,
+      )
+
+      stub = stub_request(:post, "https://api.easee.cloud/api/chargers/C123/commands/poll_lifetimeenergy")
+        .with(headers: { "Authorization" => "Bearer T123" })
+        .to_return(status: 200, body: "")
+
+      client = Easee::Client.new(user_name: "easee", password: "money", token_cache:)
+
+      client.poll_lifetime_energy("C123")
+
+      expect(stub).to have_been_requested
+    end
+  end
+
   describe "#inspect" do
     it "does not include the user name and password" do
       token_cache = ActiveSupport::Cache::MemoryStore.new


### PR DESCRIPTION
Sending this command triggers the charger to invalidate the meter reading cache.