### PR TITLE
Correctly handle Amazon GW forbidden errors

### DIFF
--- a/lib/easee/amazon_gw_middleware.rb
+++ b/lib/easee/amazon_gw_middleware.rb
@@ -1,0 +1,10 @@
+module Easee
+  class AmazonGwMiddleware < Faraday::Middleware
+    def on_complete(env)
+      return unless env.response_headers["X-Amzn-Errortype"] == "ForbiddenException"
+
+      response_values = Faraday::Response::RaiseError.new.response_values(env)
+      raise(Faraday::ForbiddenError, response_values)
+    end
+  end
+end

--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -91,6 +91,7 @@ module Easee
       Faraday.new(url: BASE_URL) do |conn|
         conn.request :json
         conn.response :raise_error
+        conn.use AmazonGwMiddleware
         conn.response :json, content_type: /\bjson$/
       end
     end

--- a/lib/stekker_easee.rb
+++ b/lib/stekker_easee.rb
@@ -13,6 +13,7 @@ require_relative "easee/meter_reading"
 require_relative "easee/site"
 require_relative "easee/state"
 require_relative "easee/charger"
+require_relative "easee/amazon_gw_middleware"
 
 module Easee
 end

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -232,6 +232,35 @@ RSpec.describe Easee::Client do
       expect { client.login }
         .to raise_error(Easee::Errors::InvalidCredentials)
     end
+
+    it "raises Forbidden errors when the request is rerouted with X-Amzn-Errortype: ForbiddenException" do
+      user_name = "test"
+      password = "old"
+
+      stub_request(:post, "https://api.easee.cloud/api/accounts/login")
+        .with(
+          body: { userName: user_name, password: }.to_json,
+        )
+        .to_return(
+          status: 301,
+          headers: {
+            Date: "Fri, 07 Jun 2024 07:30:02 GMT",
+            "Content-Type": "application/json",
+            "Content-Length": "0",
+            Connection: "keep-alive",
+            "X-Amzn-Requestid": "aaa0a000-000a-0000-a0a0-00000a00aa00",
+            "X-Amzn-Errortype": "ForbiddenException",
+            "X-Amz-Apigw-Id": "A_AAAAa0aaAAAaa=",
+            "X-Easee-Key": "a00a0000-0a0a-0a0a-aa00-0a0000a0a0a0",
+            Location: "https://blackhole.easee.com",
+          },
+        )
+
+      client = Easee::Client.new(user_name:, password:)
+
+      expect { client.login }
+        .to raise_error(Easee::Errors::Forbidden)
+    end
   end
 
   describe "#pair" do


### PR DESCRIPTION
The Amazon API gateway used by the Easee API seems to route some requests to a blackhole, possibly because we keep trying to login with outdated credentials. However, such responses should result in a Forbidden error to make sure they're dealt with correctly upstream.

This PR adds a Faraday middleware that detects the Amazon Forbidden response header and changes the response status code to 403.