### PR TITLE
Expose charging power, session energy, and operation mode from State

### DIFF
--- a/lib/easee/state.rb
+++ b/lib/easee/state.rb
@@ -18,20 +18,23 @@ module Easee
 
     def charging? = charger_op_mode == :charging
     def disconnected? = charger_op_mode == :disconnected
+    def awaiting_start? = charger_op_mode == :awaiting_start
     def online? = @data.fetch(:isOnline)
+
+    def charger_op_mode
+      numeric_op_mode = @data.fetch(:chargerOpMode)
+      CHARGER_OP_MODES.fetch(numeric_op_mode) { OP_MODE_UNKNOWN }
+    end
+
+    def total_power = @data.fetch(:totalPower).to_f
+
+    def session_energy = @data.fetch(:sessionEnergy).to_f
 
     def meter_reading
       MeterReading.new(
         reading_kwh: @data.fetch(:lifetimeEnergy),
         timestamp: Time.zone.parse(@data.fetch(:latestPulse)),
       )
-    end
-
-    private
-
-    def charger_op_mode
-      numeric_op_mode = @data.fetch(:chargerOpMode)
-      CHARGER_OP_MODES.fetch(numeric_op_mode) { OP_MODE_UNKNOWN }
     end
   end
 end

--- a/spec/easee/state_spec.rb
+++ b/spec/easee/state_spec.rb
@@ -27,6 +27,38 @@ RSpec.describe Easee::State do
     end
   end
 
+  describe "#awaiting_start?" do
+    it "returns true when the charger op mode is :awaiting_start" do
+      expect(Easee::State.new(chargerOpMode: 2)).to be_awaiting_start
+    end
+
+    it "returns false when charging" do
+      expect(Easee::State.new(chargerOpMode: 3)).not_to be_awaiting_start
+    end
+  end
+
+  describe "#charger_op_mode" do
+    it "returns the symbolic op mode" do
+      expect(Easee::State.new(chargerOpMode: 3).charger_op_mode).to eq(:charging)
+    end
+
+    it "returns :unknown for unmapped op modes" do
+      expect(Easee::State.new(chargerOpMode: 99).charger_op_mode).to eq(:unknown)
+    end
+  end
+
+  describe "#total_power" do
+    it "returns the total charging power as a float" do
+      expect(Easee::State.new(totalPower: 7.4).total_power).to eq(7.4)
+    end
+  end
+
+  describe "#session_energy" do
+    it "returns the session energy as a float" do
+      expect(Easee::State.new(sessionEnergy: 12.34).session_energy).to eq(12.34)
+    end
+  end
+
   describe "#online?" do
     it "returns true when the charger is online" do
       expect(Easee::State.new(isOnline: true)).to be_online


### PR DESCRIPTION
Maakt `total_power`, `session_energy`, `charger_op_mode` en `awaiting_start?` beschikbaar op `Easee::State`. Deze velden zitten al in de API-response maar waren niet toegankelijk.

Nodig voor feature parity met de Zaptec-connectie in StekkerWeb (charging power sampling, uncertified meter readings, connector state, state-aware pause/resume).