### PR TITLE
Add dynamic charger current control

### DIFF
--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -60,6 +60,11 @@ module Easee
       post("/api/chargers/#{charger_id}/commands/resume_charging")
     end
 
+    # https://developer.easee.cloud/reference/charger_set_dynamic_charger_current
+    def set_dynamic_charger_current(charger_id, current:)
+      post("/api/chargers/#{charger_id}/commands/set_dynamic_charger_current", body: { amps: current })
+    end
+
     # https://developer.easee.cloud/reference/get_api-chargers-id-config
     def configuration(charger_id)
       get("/api/chargers/#{charger_id}/config")

--- a/lib/easee/state.rb
+++ b/lib/easee/state.rb
@@ -30,6 +30,8 @@ module Easee
 
     def session_energy = @data.fetch(:sessionEnergy).to_f
 
+    def dynamic_charger_current = @data.fetch(:dynamicChargerCurrent).to_f
+
     def meter_reading
       MeterReading.new(
         reading_kwh: @data.fetch(:lifetimeEnergy),

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -535,6 +535,27 @@ RSpec.describe Easee::Client do
     end
   end
 
+  describe "#set_dynamic_charger_current" do
+    it "sends a set_dynamic_charger_current command" do
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      token_cache.write(
+        Easee::Client::TOKENS_CACHE_KEY,
+        { "accessToken" => "T123" }.to_json,
+      )
+
+      stub_request(:post, "https://api.easee.cloud/api/chargers/C123/commands/set_dynamic_charger_current")
+        .with(
+          headers: { "Authorization" => "Bearer T123" },
+          body: { amps: 10 }.to_json,
+        )
+        .to_return(status: 200, body: "")
+
+      client = Easee::Client.new(user_name: "easee", password: "money", token_cache:)
+
+      expect { client.set_dynamic_charger_current("C123", current: 10) }.not_to raise_error
+    end
+  end
+
   describe "#inspect" do
     it "does not include the user name and password" do
       token_cache = ActiveSupport::Cache::MemoryStore.new

--- a/spec/easee/state_spec.rb
+++ b/spec/easee/state_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Easee::State do
     end
   end
 
+  describe "#dynamic_charger_current" do
+    it "returns the dynamic charger current as a float" do
+      expect(Easee::State.new(dynamicChargerCurrent: 16.0).dynamic_charger_current).to eq(16.0)
+    end
+  end
+
   describe "#online?" do
     it "returns true when the charger is online" do
       expect(Easee::State.new(isOnline: true)).to be_online


### PR DESCRIPTION
Voegt `dynamic_charger_current` toe aan `Easee::State` en `set_dynamic_charger_current` aan `Easee::Client`, zodat StekkerWeb current control kan doen op Easee-laders.

Vervolg op #32 — die PR bevatte de state fields voor power, energy en op mode, maar nog niet de current control methods.