### PR TITLE
Use sessionId and sessionEnergy field names from Easee API

### DIFF
--- a/lib/easee/session.rb
+++ b/lib/easee/session.rb
@@ -4,8 +4,8 @@ module Easee
       @data = data.symbolize_keys
     end
 
-    def id = @data.fetch(:id)
+    def id = @data.fetch(:sessionId)
 
-    def energy = @data.fetch(:kiloWattHours).to_f
+    def energy = @data.fetch(:sessionEnergy).to_f
   end
 end

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -569,8 +569,8 @@ RSpec.describe Easee::Client do
         .to_return(
           status: 200,
           body: {
-            id: 12345,
-            kiloWattHours: 3.42,
+            sessionId: 12345,
+            sessionEnergy: 3.42,
           }.to_json,
           headers: { "Content-Type": "application/json" },
         )


### PR DESCRIPTION
Het ongoing session endpoint (`/api/chargers/{id}/sessions/ongoing`) retourneert `sessionId` en `sessionEnergy`, niet `id` en `kiloWattHours` zoals eerder aangenomen. Dit veroorzaakt een `KeyError` in productie ([Sentry #1884](https://sentry2.stekker.app/organizations/sentry/issues/1884/)).

Echt API response:
```json
{
  "chargerId": "EHEDPGGW",
  "sessionEnergy": 47.1,
  "sessionStart": "2026-04-13T15:20:42Z",
  "sessionId": 193,
  ...
}
```