### PR TITLE
Map chargerOpMode 7 (AwaitingAuthentication) and 8 (DeAuthenticating)

### DIFF
--- a/lib/easee/state.rb
+++ b/lib/easee/state.rb
@@ -10,6 +10,8 @@ module Easee
       4 => :completed,
       5 => :error,
       6 => :ready_to_charge,
+      7 => :awaiting_authentication,
+      8 => :de_authenticating,
     }.freeze
 
     def initialize(data)

--- a/spec/easee/state_spec.rb
+++ b/spec/easee/state_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Easee::State do
     end
 
     it "does not fail for unknown op modes" do
-      expect(Easee::State.new(chargerOpMode: 7)).not_to be_charging
+      expect(Easee::State.new(chargerOpMode: 99)).not_to be_charging
     end
   end
 
@@ -40,6 +40,14 @@ RSpec.describe Easee::State do
   describe "#charger_op_mode" do
     it "returns the symbolic op mode" do
       expect(Easee::State.new(chargerOpMode: 3).charger_op_mode).to eq(:charging)
+    end
+
+    it "maps awaiting authentication (7)" do
+      expect(Easee::State.new(chargerOpMode: 7).charger_op_mode).to eq(:awaiting_authentication)
+    end
+
+    it "maps de-authenticating (8)" do
+      expect(Easee::State.new(chargerOpMode: 8).charger_op_mode).to eq(:de_authenticating)
     end
 
     it "returns :unknown for unmapped op modes" do


### PR DESCRIPTION
De Easee API heeft twee chargerOpMode waarden die we niet mapten: 7 (AwaitingAuthentication) en 8 (DeAuthenticating). Als de lader in een van deze states was, kreeg `charger_op_mode` de waarde `:unknown` — wat downstream een Sentry warning triggerde in StekkerWeb.

Nu mappen we ze naar `:awaiting_authentication` en `:de_authenticating`.

Zie [Easee API enumerations](https://developer.easee.com/docs/enumerations) (Op Mode 109).