### PR TITLE
Bump faraday to 2.14.2 for security advisory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,17 +36,17 @@ GEM
       rexml
     diff-lcs (1.5.1)
     drb (2.2.3)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     gem-release (2.2.2)
     hashdiff (1.1.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
+    json (2.19.5)
     language_server-protocol (3.17.0.3)
     logger (1.7.0)
     minitest (6.0.3)


### PR DESCRIPTION
Adresseert de open Dependabot alert:

- **faraday <= 2.14.1** (low) — incomplete fix voor host-scoping bypass via protocol-relative URI's (GHSA-33mh-2634-fwr2).

Tests groen (42 examples).