### PR TITLE
Recover from a rejected refresh token by logging in again

### DIFF
--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -123,28 +123,22 @@ module Easee
     end
 
     def with_error_handling
-      token_refreshed ||= false
+      reauthenticated ||= false
 
       yield
     rescue Faraday::UnauthorizedError => e
-      if token_refreshed
-        raise Errors::RequestFailed.new("Request returned status #{e.response_status}", e.response)
-      else
-        refresh_access_token!
-        token_refreshed = true
+      raise request_failed(e) if reauthenticated
 
-        retry
-      end
+      reauthenticate!
+      reauthenticated = true
+
+      retry
     rescue Faraday::TooManyRequestsError => e
       raise Errors::RateLimitExceeded.new("Rate limit exceeded", e.response)
     rescue Faraday::ForbiddenError => e
       raise Errors::Forbidden, "Access denied to charger"
     rescue Faraday::Error => e
-      if e.response_status == 400 && [100, 727].include?(e.response.dig(:body, "errorCode"))
-        raise Errors::InvalidCredentials, "Invalid username or password"
-      end
-
-      raise Errors::RequestFailed.new("Request returned status #{e.response_status}", e.response)
+      raise_credentials_or_request_error(e)
     end
 
     def access_token
@@ -157,14 +151,40 @@ module Easee
       JSON.parse(plain_text_tokens).fetch("accessToken")
     end
 
+    def reauthenticate!
+      refresh_access_token!
+    rescue Faraday::Error
+      log_in!
+    end
+
     def refresh_access_token!
+      store_tokens(refresh_access_token)
+    end
+
+    def log_in!
+      store_tokens(request_access_token)
+    rescue Faraday::Error => e
+      raise_credentials_or_request_error(e)
+    end
+
+    def store_tokens(tokens)
       @token_cache.write(
         TOKENS_CACHE_KEY,
-        @encryptor.encrypt(refresh_access_token.to_json, cipher_options: { deterministic: true }),
+        @encryptor.encrypt(tokens.to_json, cipher_options: { deterministic: true }),
         expires_in: 1.day,
       )
-    rescue Faraday::Error => e
-      raise Errors::RequestFailed.new("Request returned status #{e.response_status}", e.response)
+    end
+
+    def raise_credentials_or_request_error(error)
+      if error.response_status == 400 && [100, 727].include?(error.response.dig(:body, "errorCode"))
+        raise Errors::InvalidCredentials, "Invalid username or password"
+      end
+
+      raise request_failed(error)
+    end
+
+    def request_failed(error)
+      Errors::RequestFailed.new("Request returned status #{error.response_status}", error.response)
     end
 
     # https://developer.easee.cloud/reference/post_api-accounts-login

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -89,7 +89,46 @@ RSpec.describe Easee::Client do
       expect { client.pair(charger_id: "123ABC", pin_code: "1234") }.to raise_error(Easee::Errors::RequestFailed)
     end
 
-    it "fails when the acess token could not be refreshed" do
+    it "logs in with username and password when the refresh token is rejected" do
+      user_name = "easee"
+      password = "money"
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      current_tokens = { "accessToken" => "T123", "refreshToken" => "R456" }
+      token_cache.write(Easee::Client::TOKENS_CACHE_KEY, current_tokens.to_json)
+      new_tokens = { "accessToken" => "T999" }
+
+      stub_request(:post, "https://api.easee.cloud/api/chargers/123ABC/pair?pinCode=1234")
+        .to_return(
+          { status: 401, body: "Invalid token" },
+          { status: 200, body: "" },
+        )
+
+      stub_request(:post, "https://api.easee.cloud/api/accounts/refresh_token")
+        .to_return(
+          status: 401,
+          body: { errorCode: 104, errorCodeName: "InvalidRefreshToken" }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      login_request = stub_request(:post, "https://api.easee.cloud/api/accounts/login")
+        .with(body: { userName: user_name, password: }.to_json)
+        .to_return(
+          status: 200,
+          body: new_tokens.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      client = Easee::Client.new(user_name:, password:, token_cache:)
+
+      expect { client.pair(charger_id: "123ABC", pin_code: "1234") }
+        .to change { token_cache.fetch(Easee::Client::TOKENS_CACHE_KEY) }
+        .from(current_tokens.to_json)
+        .to(new_tokens.to_json)
+
+      expect(login_request).to have_been_requested
+    end
+
+    it "raises InvalidCredentials when the refresh fails and re-login is rejected" do
       user_name = "easee"
       password = "money"
       token_cache = ActiveSupport::Cache::MemoryStore.new
@@ -97,27 +136,26 @@ RSpec.describe Easee::Client do
       token_cache.write(Easee::Client::TOKENS_CACHE_KEY, current_tokens.to_json)
 
       stub_request(:post, "https://api.easee.cloud/api/chargers/123ABC/pair?pinCode=1234")
-        .to_return(
-          status: 401, body: "Invalid token",
-        )
+        .to_return(status: 401, body: "Invalid token")
 
       stub_request(:post, "https://api.easee.cloud/api/accounts/refresh_token")
-        .with(
-          body: { accessToken: "T123", refreshToken: "R456" }.to_json,
-        )
         .to_return(
           status: 401,
-          body: {
-            errorCode: 104,
-            errorCodeName: "InvalidRefreshToken",
-          }.to_json,
+          body: { errorCode: 104, errorCodeName: "InvalidRefreshToken" }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      stub_request(:post, "https://api.easee.cloud/api/accounts/login")
+        .to_return(
+          status: 400,
+          body: { errorCode: 100, errorCodeName: "InvalidUserPassword" }.to_json,
           headers: { "Content-Type": "application/json" },
         )
 
       client = Easee::Client.new(user_name:, password:, token_cache:)
 
       expect { client.pair(charger_id: "123ABC", pin_code: "1234") }
-        .to raise_error(Easee::Errors::RequestFailed)
+        .to raise_error(Easee::Errors::InvalidCredentials)
     end
 
     it "uses the encryptor to encrypt the tokens" do


### PR DESCRIPTION
Lost het 401-stormpatroon op dat we in productie zagen op het gedeelde Easee-account (Sentry stekker#2017): bij een afgewezen refresh-token logt de client nu opnieuw in met username/wachtwoord in plaats van te blijven hangen op 401's.

## Aanleiding

Sentry stekker#2017: `Connections::ChargePointConnection::RequestFailed: status 401` op `GET /api/chargers/{id}/state`, ~800 events over één account met meerdere laders, in bursts van ~3 tegelijk per refresh-cyclus. Productie-console bevestigde: de credentials zijn geldig (verse login werkt), en het herstelde zichzelf pas zodra de cache-token verliep.

## Root cause

Easee refresh-tokens zijn **single-use en sessie-gebonden** ([changelog](https://developer.easee.com/changelog/refresh-token-handling)). Wanneer meerdere requests voor hetzelfde account tegelijk een 401 krijgen, racen ze op dezelfde refresh-token: de "verliezers" hergebruiken een al-verbruikte token, die Easee afwijst en die de sessie kan opruimen. De oude `with_error_handling` deed één refresh en gaf het daarna op (`Errors::RequestFailed`), waardoor elke poll 401 bleef geven tot de gecachte token verliep (uren) — vandaar de storm.

Easee's eigen advies hierbij: *"Fall back to username/password authentication when token refresh fails."*

## Wijziging

`with_error_handling` herauthenticeert nu één keer en geeft daarna pas op. De herauthenticatie (`reauthenticate!`) probeert eerst een refresh en valt bij een afgewezen refresh terug op een **volledige login** (`request_access_token`). Daardoor herstelt de client zich op de volgende call i.p.v. te blijven loopen op 401's.

- Een login die faalt met ongeldige credentials blijft een `InvalidCredentials` opleveren (zodat de caller een echt ongeldig account nog steeds kan loskoppelen).
- Niet-401 fouten (rate limit, 403, 5xx) behouden hun bestaande gedrag.

## Reproductie

`spec/easee/client_spec.rb`:
- "logs in with username and password when the refresh token is rejected" — refresh faalt → login slaagt → request herstelt; faalde vóór de wijziging met `RequestFailed`.
- "raises InvalidCredentials when the refresh fails and re-login is rejected" — echt ongeldige credentials blijven `InvalidCredentials`.

## Vervolg

Na merge moet StekkerWeb de gem bumpen (`bundle update stekker_easee`, die `github: "stekker/easee", branch: "main"` volgt) om de fix in productie te krijgen. Een per-account lock om de gelijktijdige re-logins verder te beperken kan eventueel later in StekkerWeb via job-serialisatie — niet nodig voor correctheid, want de re-login fallback voorkomt de aanhoudende storm.