### PR TITLE
Raise typed errors for the two known pair-endpoint failures

### DIFF
--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -176,9 +176,14 @@ module Easee
     end
 
     def raise_credentials_or_request_error(error)
-      if error.response_status == 400 && [100, 727].include?(error.response.dig(:body, "errorCode"))
+      body_error_code = error.response&.dig(:body, "errorCode")
+
+      if error.response_status == 400 && [100, 727].include?(body_error_code)
         raise Errors::InvalidCredentials, "Invalid username or password"
       end
+
+      raise Errors::InvalidPinCode.new("PIN code rejected", error.response) if body_error_code == 193
+      raise Errors::ChargerNotFound.new("Charger not found", error.response) if body_error_code == 400
 
       raise request_failed(error)
     end

--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -176,14 +176,14 @@ module Easee
     end
 
     def raise_credentials_or_request_error(error)
-      body_error_code = error.response&.dig(:body, "errorCode")
-
-      if error.response_status == 400 && [100, 727].include?(body_error_code)
+      case error.response&.dig(:body, "errorCode")
+      when *Errors::InvalidCredentials::CODES
         raise Errors::InvalidCredentials, "Invalid username or password"
+      when Errors::InvalidPinCode::CODE
+        raise Errors::InvalidPinCode.new("PIN code rejected", error.response)
+      when Errors::ChargerNotFound::CODE
+        raise Errors::ChargerNotFound.new("Charger not found", error.response)
       end
-
-      raise Errors::InvalidPinCode.new("PIN code rejected", error.response) if body_error_code == 193
-      raise Errors::ChargerNotFound.new("Charger not found", error.response) if body_error_code == 400
 
       raise request_failed(error)
     end

--- a/lib/easee/errors.rb
+++ b/lib/easee/errors.rb
@@ -4,7 +4,9 @@ module Easee
       def retryable? = false
     end
 
-    class InvalidCredentials < Base; end
+    class InvalidCredentials < Base
+      CODES = [100, 727].freeze
+    end
 
     class RequestFailed < Base
       attr_reader :response
@@ -17,9 +19,13 @@ module Easee
 
     class Forbidden < Base; end
 
-    class InvalidPinCode < RequestFailed; end
+    class InvalidPinCode < RequestFailed
+      CODE = 193
+    end
 
-    class ChargerNotFound < RequestFailed; end
+    class ChargerNotFound < RequestFailed
+      CODE = 400
+    end
 
     class RateLimitExceeded < RequestFailed
       def retryable? = true

--- a/lib/easee/errors.rb
+++ b/lib/easee/errors.rb
@@ -17,6 +17,10 @@ module Easee
 
     class Forbidden < Base; end
 
+    class InvalidPinCode < RequestFailed; end
+
+    class ChargerNotFound < RequestFailed; end
+
     class RateLimitExceeded < RequestFailed
       def retryable? = true
     end

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -317,6 +317,56 @@ RSpec.describe Easee::Client do
 
       expect { client.pair(charger_id: "123ABC", pin_code: "1234") }.not_to raise_error
     end
+
+    it "raises InvalidPinCode when Easee rejects the PIN (errorCode 193)" do
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      token_cache.write(
+        Easee::Client::TOKENS_CACHE_KEY,
+        { "accessToken" => "T123" }.to_json,
+      )
+
+      stub_request(:post, "https://api.easee.cloud/api/chargers/123ABC/pair?pinCode=WRONG")
+        .with(headers: { "Authorization" => "Bearer T123" })
+        .to_return(
+          status: 400,
+          body: {
+            errorCode: 193,
+            errorCodeName: "NotPossibleToGrantAccessWithPinCode",
+            title: "Not possible to grant access with pin code",
+          }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      client = Easee::Client.new(user_name: "easee", password: "money", token_cache:)
+
+      expect { client.pair(charger_id: "123ABC", pin_code: "WRONG") }
+        .to raise_error(Easee::Errors::InvalidPinCode)
+    end
+
+    it "raises ChargerNotFound when the charger is unknown (errorCode 400)" do
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      token_cache.write(
+        Easee::Client::TOKENS_CACHE_KEY,
+        { "accessToken" => "T123" }.to_json,
+      )
+
+      stub_request(:post, "https://api.easee.cloud/api/chargers/UNKNOWN/pair?pinCode=1234")
+        .with(headers: { "Authorization" => "Bearer T123" })
+        .to_return(
+          status: 404,
+          body: {
+            errorCode: 400,
+            errorCodeName: "ChargerNotFound",
+            title: "Charger not found",
+          }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      client = Easee::Client.new(user_name: "easee", password: "money", token_cache:)
+
+      expect { client.pair(charger_id: "UNKNOWN", pin_code: "1234") }
+        .to raise_error(Easee::Errors::ChargerNotFound)
+    end
   end
 
   describe "#unpair" do


### PR DESCRIPTION
Voortgekomen uit StekkerWeb PR https://github.com/stekker/stekker/pull/8057 (Easee-pairing fouten specifiek maken voor eindgebruikers). De errorCode → typed-exception translatie hoort in de gem zelf, niet in de StekkerWeb-connection.

Twee nieuwe subclasses van `Errors::RequestFailed`:

- `Errors::InvalidPinCode` — `errorCode: 193` (NotPossibleToGrantAccessWithPinCode), pincode wordt afgewezen door Easee
- `Errors::ChargerNotFound` — `errorCode: 400` (ChargerNotFound), serienummer onbekend bij Easee (paal niet geclaimd of typo)

Backward compatible: beide erven van `Errors::RequestFailed`, dus bestaande `rescue Easee::Errors::RequestFailed`-code blijft werken; nieuwe code kan specifieker rescuen.

Mapping in `raise_credentials_or_request_error` houdt de bestaande 100/727 InvalidCredentials-check (login-pad) intact en voegt de twee nieuwe codes ernaast toe. Match op `errorCode` (numeriek, stabiel) ipv `errorCodeName` (string-naam die hernoemd kan worden).

Tests via WebMock met de echte response-body-vorm.

Na merge: gem-bump in StekkerWeb + cleanup van `Connections::Easee#with_translated_errors` daar.