### PR TITLE
Fetch a single Easee charger by id

### DIFF
--- a/lib/easee/client.rb
+++ b/lib/easee/client.rb
@@ -44,6 +44,12 @@ module Easee
       end
     end
 
+    # https://developer.easee.cloud/reference/get_api-chargers-id
+    def charger(charger_id)
+      get("/api/chargers/#{charger_id}")
+        .then { |response| Charger.new(response.body) }
+    end
+
     # https://developer.easee.cloud/reference/get_api-chargers-id-state
     def state(charger_id)
       get("/api/chargers/#{charger_id}/state")

--- a/spec/easee/client_spec.rb
+++ b/spec/easee/client_spec.rb
@@ -436,6 +436,38 @@ RSpec.describe Easee::Client do
     end
   end
 
+  describe "#charger" do
+    it "fetches a single charger by id" do
+      token_cache = ActiveSupport::Cache::MemoryStore.new
+      token_cache.write(
+        Easee::Client::TOKENS_CACHE_KEY,
+        { "accessToken" => "T123" }.to_json,
+      )
+
+      stub_request(:get, "https://api.easee.cloud/api/chargers/EASEE123")
+        .with(headers: { "Authorization" => "Bearer T123" })
+        .to_return(
+          status: 200,
+          body: {
+            id: "EASEE123",
+            name: "EaseeChargePro",
+            color: 11,
+            productCode: 103,
+          }.to_json,
+          headers: { "Content-Type": "application/json" },
+        )
+
+      client = Easee::Client.new(user_name: "easee", password: "money", token_cache:)
+
+      expect(client.charger("EASEE123")).to have_attributes(
+        id: "EASEE123",
+        name: "EaseeChargePro",
+        color: 11,
+        product_code: 103,
+      )
+    end
+  end
+
   describe "#configuration" do
     it "fetches the technical configuration" do
       token_cache = ActiveSupport::Cache::MemoryStore.new


### PR DESCRIPTION
Voegt `Client#charger(id)` toe: één `GET /api/chargers/{id}` die een `Charger` teruggeeft (incl. `productCode`), zodat callers voor het resolven van één laadpaal niet de hele account-lijst hoeven te pagineren.

Nodig voor de charge-point-model-resolutie in StekkerWeb (stekker/stekker#8245): per lader één API-call i.p.v. de volledige lijst. De single-charger-response is op productie geverifieerd — die bevat `productCode` (bevestigd met een echte Charge Pro: `productCode: 103`).