### PR TITLE
Patch faraday NestedParamsEncoder recursion DoS advisory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       rexml
     diff-lcs (1.5.1)
     drb (2.2.3)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger


### PR DESCRIPTION
Bumpt `faraday` van 2.14.2 → 2.14.3.

Dicht Dependabot alert [#50](https://github.com/stekker/easee/security/dependabot/50): uncontrolled recursion in `NestedParamsEncoder` maakt een stack-exhaustion DoS mogelijk via diep-geneste query parameters.