### PR TITLE
Patch concurrent-ruby lock and atomic-reference advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     ast (2.4.2)
     base64 (0.3.0)
     bigdecimal (4.1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.0)
       bigdecimal


### PR DESCRIPTION
Bumpt `concurrent-ruby` van 1.3.6 → 1.3.7.

Dicht drie Dependabot alerts:
- [#48](https://github.com/stekker/easee/security/dependabot/48) — `AtomicReference#update` livelocks bij `Float::NAN` (high)
- [#49](https://github.com/stekker/easee/security/dependabot/49) — `ReentrantReadWriteLock` read-count overflow grants write lock without exclusivity
- [#47](https://github.com/stekker/easee/security/dependabot/47) — `ReadWriteLock` allows wrong-thread write release and read-release counter corruption