### PR TITLE
Expose sessionStart and sessionEnd on ongoing sessions

### DIFF
--- a/lib/easee/session.rb
+++ b/lib/easee/session.rb
@@ -7,5 +7,17 @@ module Easee
     def id = @data.fetch(:sessionId)
 
     def energy = @data.fetch(:sessionEnergy).to_f
+
+    def session_start = parse_time(:sessionStart)
+    def session_end = parse_time(:sessionEnd)
+
+    private
+
+    def parse_time(key)
+      value = @data[key]
+      return if value.nil?
+
+      Time.zone.parse(value)
+    end
   end
 end

--- a/spec/easee/session_spec.rb
+++ b/spec/easee/session_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Easee::Session do
+  it "exposes the session fields" do
+    session = described_class.new(
+      "sessionId" => 12345,
+      "sessionEnergy" => 3.42,
+      "sessionStart" => "2026-01-05T10:00:00Z",
+      "sessionEnd" => "2026-01-05T11:30:00Z",
+    )
+
+    expect(session).to have_attributes(
+      id: 12345,
+      energy: 3.42,
+      session_start: Time.zone.parse("2026-01-05T10:00:00Z"),
+      session_end: Time.zone.parse("2026-01-05T11:30:00Z"),
+    )
+  end
+
+  it "returns nil for session_start and session_end when the fields are missing or null" do
+    session = described_class.new(
+      "sessionId" => 12345,
+      "sessionEnergy" => 0.0,
+      "sessionStart" => nil,
+      "sessionEnd" => nil,
+    )
+
+    expect(session).to have_attributes(
+      session_start: nil,
+      session_end: nil,
+    )
+  end
+end


### PR DESCRIPTION
De `UsageStatisticsDTO` die de [`GET /api/chargers/{id}/sessions/ongoing`](https://developer.easee.com/reference/chargers_getongoingsessiondetails) endpoint teruggeeft, bevat `sessionStart` (start van de lopende sessie) en `sessionEnd` (nullable — enkel gevuld nadat de sessie is afgesloten). We parsen die nu ook. Onderdeel van [stekker/backlog#1996](https://github.com/stekker/backlog/issues/1996): daar willen we `session.start_at` in StekkerWeb vullen met de canonieke charger-timestamp in plaats van `Time.current`.

## Wat er verandert

`Easee::Session` heeft twee extra readers:

```ruby
session.session_start  # => ActiveSupport::TimeWithZone
session.session_end    # => ActiveSupport::TimeWithZone of nil (nil = sessie loopt nog)
```

Beide zijn tolerant: ontbrekend of `null` in de payload → `nil`.

De bestaande `#id` en `#energy` blijven ongewijzigd.